### PR TITLE
Fallback to full pool when selection below lineup size

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,9 +594,8 @@ function generateLineupsMaxSpend(){
 
 function setDynamicCapDefaults(){
   const cfg = SPORT_CONFIGS[state.detectedSport];
-  const pool = state.players.filter(p=>p.selected).length
-    ? state.players.filter(p=>p.selected)
-    : state.players;
+  const selected = state.players.filter(p=>p.selected);
+  const pool = selected.length >= cfg.lineupSize ? selected : state.players;
 
   const top = [...pool].sort((a,b)=>b.salary-a.salary).slice(0, cfg.lineupSize);
   const target = top.reduce((s,p)=>s+p.salary, 0);


### PR DESCRIPTION
## Summary
- Only use selected players for dynamic cap defaults if at least the sport's lineup size are selected
- Otherwise fall back to using the entire player pool

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c49062cb008329be203b677a412e15