### PR TITLE
Add helper for quoted CSV row generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,6 +488,8 @@ function renderLineups(){ const cfg=SPORT_CONFIGS[state.detectedSport]; const bo
   <td>${cfg.currency}${l.totalSalary}</td>
 </tr>`).join(''); document.getElementById('lineupResults').textContent = state.lineups.length; updateDownloadLink(); document.getElementById('downloadBtn').toggleAttribute('disabled', state.lineups.length===0); }
 
+const csvRow = row => row.map(f => `"${String(f).replace(/"/g,'""')}"`).join(',');
+
 function updateDownloadLink(){
   const cfg=SPORT_CONFIGS[state.detectedSport];
   const use=usesCaptains(state.detectedSport, state.contestType);
@@ -502,7 +504,7 @@ function updateDownloadLink(){
     rows.push(names);
   });
 
-  const csv = rows.map(r=>r.join(',')).join('\n');
+  const csv = rows.map(csvRow).join('\n');
   const blob=new Blob([csv],{type:'text/csv'});
   const dl=document.getElementById('downloadBtn');
   dl.href = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- introduce `csvRow` helper to quote and escape fields when exporting lineups
- use `csvRow` to build CSV string for download

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c49060ad708329afc22a5a8edb8a18