### PR TITLE
Fallback to full pool when selection below lineup size

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,8 +402,6 @@ async function importCSV(file){
   if(!players.length) throw new Error('No valid players found');
   return players;
 }
- codex/refactor-fanteam-dfs-optimizer
- main
 // Load a demo CSV by KEY (uses same pipeline as uploads)
 async function loadDemoCsv(key){
   const preset = DEMO_CSVS[key];
@@ -594,9 +592,8 @@ function generateLineupsMaxSpend(){
 
 function setDynamicCapDefaults(){
   const cfg = SPORT_CONFIGS[state.detectedSport];
-  const pool = state.players.filter(p=>p.selected).length
-    ? state.players.filter(p=>p.selected)
-    : state.players;
+  const selected = state.players.filter(p=>p.selected);
+  const pool = selected.length >= cfg.lineupSize ? selected : state.players;
 
   const top = [...pool].sort((a,b)=>b.salary-a.salary).slice(0, cfg.lineupSize);
   const target = top.reduce((s,p)=>s+p.salary, 0);
@@ -616,8 +613,20 @@ uploadZone.addEventListener('dragleave',()=>uploadZone.classList.remove('dragove
 uploadZone.addEventListener('drop',e=>{ e.preventDefault(); uploadZone.classList.remove('dragover'); const f=e.dataTransfer.files; if(f.length) processFile(f[0]); });
 fileInput.addEventListener('change',e=>{ if(e.target.files.length) processFile(e.target.files[0]); });
 
-async function processFile(file){ try{ const players = await importCSV(file); state.players = players; state.detectedSport = detectSportFromCSV(players); state.datasetMeta = { tournament: file.name.replace(/\.csv$/i,''), eventName: 'Imported CSV' }; uploadZone.classList.add('has-file'); showToast(`Loaded ${players.length} players`,`success`); updateDetection(); setStep(2); }
-catch(err){ showToast(err.message,'error'); } }
+async function processFile(file){
+  try {
+    const players = await importCSV(file);
+    state.players = players;
+    state.detectedSport = detectSportFromCSV(players);
+    state.datasetMeta = { tournament: file.name.replace(/\.csv$/i,''), eventName: 'Imported CSV' };
+    uploadZone.classList.add('has-file');
+    showToast(`Loaded ${players.length} players`,`success`);
+    updateDetection();
+    setStep(2);
+  } catch(err){
+    showToast(err.message,'error');
+  }
+}
 
 // Demo cycle (uses KEY rotation) — FIXED: single declaration of DEMO_ROTATION & demoIndex
 


### PR DESCRIPTION
## Summary
- Only use selected players for dynamic cap defaults if at least the sport's lineup size are selected
- Remove stray lines and format `processFile` to restore demo & upload interactions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c49062cb008329be203b677a412e15