### PR TITLE
Fix demo dataset mapping and add player team filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@ hr.sep{border:none;border-top:1px solid #1b2131;margin:12px 0}
       <h3 style="margin:0;flex:1">👥 Player management</h3>
       <input id="searchPlayers" type="text" placeholder="Search by name..." style="max-width:180px" />
       <select id="positionFilter" style="max-width:120px"><option value="">All positions</option></select>
+      <select id="teamFilter" style="max-width:120px"><option value="">All teams</option></select>
     </div>
     <div class="btn-group" style="margin-bottom:8px">
       <button class="btn" id="selectAll">Select all</button>
@@ -258,12 +259,12 @@ hr.sep{border:none;border-top:1px solid #1b2131;margin:12px 0}
 
 // Real demo CSV datasets served from /demo (Vercel/static hosting)
 const DEMO_CSVS = {
-  nfl_full: { label:'NFL — Full slate', sport:'nfl', contest:'full-slate', tournament:'Tournament 1009899 (846 players)', eventName:'NFL Week 1 Full Slate', url:'./demo/1009899_players_20250908161603.csv' },
-  nfl_show: { label:'NFL — Showdown', sport:'nfl', contest:'showdown', tournament:'Tournament 1010808 (52 players)', eventName:'NFL Showdown (Single Game)', url:'./demo/1010808_players_20250908161619.csv' },
-  fb_full:  { label:'Football — CL full slate', sport:'football', contest:'full-slate', tournament:'Tournament 1008839 (414 players)', eventName:'Champions League Night', url:'./demo/1008839_players_20250906222543.csv' },
-  fb_show:  { label:'Football — Showdown', sport:'football', contest:'showdown', tournament:'Tournament 1008665 (30 players)', eventName:'Real Madrid vs Manchester City', url:'./demo/1008665_players_20250906172857.csv' },
-  f1_full:  { label:'F1 — Race weekend', sport:'f1', contest:'full-slate', tournament:'Tournament 1009037 (34 players)', eventName:'F1 Race Weekend', url:'./demo/1009037_players_20250908102649.csv' },
-  golf_full:{ label:'Golf — PGA tournament', sport:'golf', contest:'full-slate', tournament:'Tournament 1002987 (69 players)', eventName:'PGA Tournament', url:'./demo/1000000_players_20250815093906.csv' }
+  nfl_full: { label:'NFL — Full slate', sport:'nfl', contest:'full-slate', tournament:'Tournament 1008839 (413 players)', eventName:'NFL Example Slate', url:'./demo/1008839_players_20250906222543.csv' },
+  nfl_show: { label:'NFL — Showdown', sport:'nfl', contest:'showdown', tournament:'Tournament 1009037 (33 players)', eventName:'NFL Showdown (Single Game)', url:'./demo/1009037_players_20250908102649.csv' },
+  fb_full:  { label:'Football — Full slate', sport:'football', contest:'full-slate', tournament:'Tournament 1009899 (845 players)', eventName:'Champions League Night', url:'./demo/1009899_players_20250908161603.csv' },
+  fb_show:  { label:'Football — Showdown', sport:'football', contest:'showdown', tournament:'Tournament 1010808 (51 players)', eventName:'Football Showdown', url:'./demo/1010808_players_20250908161619.csv' },
+  f1_full:  { label:'F1 — Race weekend', sport:'f1', contest:'full-slate', tournament:'Tournament 1008665 (29 players)', eventName:'F1 Race Weekend', url:'./demo/1008665_players_20250906172857.csv' },
+  golf_full:{ label:'Golf — PGA tournament', sport:'golf', contest:'full-slate', tournament:'Tournament 1000000 (585 players)', eventName:'PGA Tournament', url:'./demo/1000000_players_20250815093906.csv' }
 };
 
 // Rotation order for the demo button (array of KEYS)
@@ -407,8 +408,6 @@ async function importCSV(file){
   if(!players.length) throw new Error('No valid players found');
   return players;
 }
- codex/refactor-fanteam-dfs-optimizer
- main
 // Load a demo CSV by KEY (uses same pipeline as uploads)
 async function loadDemoCsv(key){
   state.isDemo = true;
@@ -451,9 +450,29 @@ function refreshCaptainButtons(){ const btn=document.getElementById('captainAll'
   const cfg = SPORT_CONFIGS[state.detectedSport]; const min=+document.getElementById('minSalary').value||cfg.salaryRange[0]; const max=+document.getElementById('maxSalary').value||cfg.salaryRange[1]; const ct = use? 'Captain required' : 'No captain'; document.getElementById('constraintsText').textContent = `${cfg.name} • ${state.contestType} • Lineup size ${cfg.lineupSize} • ${ct} • Salary ${cfg.currency}${min}–${cfg.currency}${max}`;
 }
 
-function derivePositionOptions(){ const sel=document.getElementById('positionFilter'); sel.innerHTML = '<option value="">All positions</option>'; const uniq=[...new Set(state.players.map(p=>p.position).filter(Boolean))].sort(); uniq.forEach(pos=>{ const o=document.createElement('option'); o.value=pos; o.textContent=pos; sel.appendChild(o); }); }
+function deriveFilters(){
+  const posSel=document.getElementById('positionFilter');
+  posSel.innerHTML = '<option value="">All positions</option>';
+  const positions=[...new Set(state.players.map(p=>p.position).filter(Boolean))].sort();
+  positions.forEach(pos=>{ const o=document.createElement('option'); o.value=pos; o.textContent=pos; posSel.appendChild(o); });
 
-function filteredPlayers(){ const q=document.getElementById('searchPlayers').value.toLowerCase(); const pf=document.getElementById('positionFilter').value; return state.players.filter(p=>{ const s=!q || p.name.toLowerCase().includes(q); const m=!pf || p.position===pf; return s&&m; }); }
+  const teamSel=document.getElementById('teamFilter');
+  teamSel.innerHTML = '<option value="">All teams</option>';
+  const teams=[...new Set(state.players.map(p=>p.team).filter(Boolean))].sort();
+  teams.forEach(team=>{ const o=document.createElement('option'); o.value=team; o.textContent=team; teamSel.appendChild(o); });
+}
+
+function filteredPlayers(){
+  const q=document.getElementById('searchPlayers').value.toLowerCase();
+  const pf=document.getElementById('positionFilter').value;
+  const tf=document.getElementById('teamFilter').value;
+  return state.players.filter(p=>{
+    const s=!q || p.name.toLowerCase().includes(q);
+    const m=!pf || p.position===pf;
+    const t=!tf || p.team===tf;
+    return s && m && t;
+  });
+}
 
 function renderPlayers(){ const cfg = SPORT_CONFIGS[state.detectedSport]; const body=document.getElementById('playerTableBody'); body.innerHTML = filteredPlayers().map(p=>{ const rowClass = p.status==='expected'? 'row-expected' : (p.status==='possible'? 'row-possible' : 'row-unexpected'); return `<tr class="${rowClass}">
   <td><input type="checkbox" ${p.selected?'checked':''} onchange="toggleSelected('${p.id}')" /></td>
@@ -601,8 +620,24 @@ uploadZone.addEventListener('dragleave',()=>uploadZone.classList.remove('dragove
 uploadZone.addEventListener('drop',e=>{ e.preventDefault(); uploadZone.classList.remove('dragover'); const f=e.dataTransfer.files; if(f.length) processFile(f[0]); });
 fileInput.addEventListener('change',e=>{ if(e.target.files.length) processFile(e.target.files[0]); });
 
-async function processFile(file){ try{ const players = await importCSV(file); state.players = players; state.detectedSport = detectSportFromCSV(players); state.datasetMeta = { tournament: file.name.replace(/\.csv$/i,''), eventName: 'Imported CSV' }; state.isDemo=false; uploadZone.classList.add('has-file'); showToast(`Loaded ${players.length} players`,`success`); updateDetection(); setStep(2); }
-catch(err){ showToast(err.message,'error'); } }
+async function processFile(file) {
+  try {
+    const players = await importCSV(file);
+    state.players = players;
+    state.detectedSport = detectSportFromCSV(players);
+    state.datasetMeta = {
+      tournament: file.name.replace(/\.csv$/i, ''),
+      eventName: 'Imported CSV'
+    };
+    state.isDemo = false;
+    uploadZone.classList.add('has-file');
+    showToast(`Loaded ${players.length} players`, `success`);
+    updateDetection();
+    setStep(2);
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
 
 // Demo cycle (uses KEY rotation) — FIXED: single declaration of DEMO_ROTATION & demoIndex
 
@@ -616,6 +651,7 @@ document.getElementById('demoBtn').addEventListener('click', async () => {
     state.currentDemoSport = demo.sport;
     state.contestType = demo.contest;
     state.datasetMeta = { tournament: demo.tournament, eventName: demo.eventName };
+    state.isDemo = true;
     updateDetection();
     showToast(`Demo loaded: ${DEMO_CSVS[key].label} (${demo.players.length} players)`);
     setStep(2);
@@ -652,7 +688,7 @@ document.getElementById('confirmContest').addEventListener('click',()=>{
 
   setDynamicCapDefaults();   // ← dynamic min/max based on this slate
 
-  derivePositionOptions();
+  deriveFilters();
   updateStats();
   renderPlayers();
   refreshCaptainButtons();
@@ -660,7 +696,15 @@ document.getElementById('confirmContest').addEventListener('click',()=>{
 });
 
 // Generate
-document.getElementById('generateBtn').addEventListener('click',()=>{   try{     state.lineups = generateLineupsMaxSpend();   // ← use max-spend     renderLineups();     showToast(`Generated ${state.lineups.length} lineups!`,'success');   } catch(err){     showToast(err.message,'error');   } });
+document.getElementById('generateBtn').addEventListener('click', () => {
+  try {
+    state.lineups = generateLineupsMaxSpend(); // ← use max-spend
+    renderLineups();
+    showToast(`Generated ${state.lineups.length} lineups!`, 'success');
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+});
 
 // Player controls
 document.getElementById('selectAll').addEventListener('click',()=>{ state.players.forEach(p=>p.selected=true); updateStats(); renderPlayers(); });
@@ -671,6 +715,7 @@ document.getElementById('clearResults').addEventListener('click',()=>{ state.lin
 document.getElementById('startOver').addEventListener('click',()=>{ state.players=[]; state.lineups=[]; state.currentDemoSport='nfl'; state.datasetMeta={tournament:'',eventName:''}; state.isDemo=false; document.getElementById('downloadBtn').setAttribute('disabled',''); uploadZone.classList.remove('has-file'); setStep(1); });
 document.getElementById('searchPlayers').addEventListener('input',renderPlayers);
 document.getElementById('positionFilter').addEventListener('change',renderPlayers);
+document.getElementById('teamFilter').addEventListener('change',renderPlayers);
 
 // Expose for checkboxes
 window.toggleSelected = id => { const p=state.players.find(x=>x.id===id); if(!p) return; p.selected=!p.selected; if(!p.selected) p.captain=false; updateStats(); renderPlayers(); };


### PR DESCRIPTION
## Summary
- Correct demo CSV mapping so each sport loads the proper players
- Add team filter dropdown to player management for easier navigation

## Testing
- `node --check /tmp/index_script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c494e0b1d88329a4f822a538b14f2a