### PR TITLE
Resolve index.html merge conflict

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,13 +204,20 @@ hr.sep{border:none;border-top:1px solid #1b2131;margin:12px 0}
       <input id="searchPlayers" type="text" placeholder="Search by name..." style="max-width:180px" />
       <select id="positionFilter" style="max-width:120px"><option value="">All positions</option></select>
       <select id="teamFilter" style="max-width:120px"><option value="">All teams</option></select>
+      <select id="salarySort" style="max-width:130px">
+        <option value="">Sort salary</option>
+        <option value="asc">Salary ↑</option>
+        <option value="desc">Salary ↓</option>
+      </select>
     </div>
     <div class="btn-group" style="margin-bottom:8px">
       <button class="btn" id="selectAll">Select all</button>
       <button class="btn" id="selectNone">Clear all</button>
       <button class="btn" id="selectExpected">Expected only</button>
       <button class="btn" id="captainAll">Captain all</button>
+      <button class="btn" id="importProj">Import projections</button>
     </div>
+    <input type="file" id="projInput" accept=".csv" hidden />
 
     <div class="scroller">
       <table class="table">
@@ -221,6 +228,7 @@ hr.sep{border:none;border-top:1px solid #1b2131;margin:12px 0}
             <th>Player</th>
             <th>Pos</th>
             <th>Team</th>
+            <th>Proj</th>
             <th>Salary</th>
             <th>Status</th>
           </tr>
@@ -279,7 +287,7 @@ const SPORT_CONFIGS = {
   f1:{ name:'Formula 1', icon:'🏎️', lineupSize:6, positions:['DRIVER','CONSTRUCTOR'], salaryRange:[98,102], currency:'£', fullSlateSize:34, showdownSize:34 }
 };
 
-const state = { currentStep:1, players:[], lineups:[], detectedSport:'nfl', contestType:'full-slate', currentDemoSport:'nfl', datasetMeta:{ tournament:'', eventName:'' }, isDemo:false };
+const state = { currentStep:1, players:[], lineups:[], detectedSport:'nfl', contestType:'full-slate', currentDemoSport:'nfl', datasetMeta:{ tournament:'', eventName:'' }, isDemo:false, statusFilter:'' };
 
 // -------------------- (Optional legacy synthetic demo, unused) --------------------
 // retained for future offline fallback
@@ -290,6 +298,7 @@ function generateDemoData(){ return { players:[], tournament:'', eventName:'', c
 const esc = (s='') => s.replace(/[&<>"']/g, c=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;' }[c]));
 const toNumber = v => { if(typeof v!== 'string') return +v||0; const cleaned = v.replace(/[^0-9.\-]/g,''); return parseFloat(cleaned)||0; };
 const norm = s => (s||'').toLowerCase().replace(/[_\s]/g,'');
+const shuffle = a => { for(let i=a.length-1;i>0;i--){ const j=Math.random()*(i+1)|0; [a[i],a[j]]=[a[j],a[i]]; } return a; };
 
 // ---- Robust column + name helpers ----
 function pickColumns(headers){
@@ -408,6 +417,29 @@ async function importCSV(file){
   if(!players.length) throw new Error('No valid players found');
   return players;
 }
+
+async function importProjections(file){
+  try {
+    const text = await file.text();
+    const rows = parseCSV(text);
+    if(rows.length<2) throw new Error('Projection CSV needs header and data');
+    const headers = rows[0].map(h=>norm(h));
+    const nameIdx = headers.findIndex(h=>['playername','fullname','full_name','player','name'].some(k=>h.includes(k)));
+    const projIdx = headers.findIndex(h=>['projection','proj','points','fpts','score'].some(k=>h.includes(k)));
+    if(nameIdx===-1 || projIdx===-1) throw new Error('Projection CSV missing name or projection column');
+    let matched=0;
+    for(let i=1;i<rows.length;i++){
+      const name=(rows[i][nameIdx]||'').trim();
+      const proj=toNumber(rows[i][projIdx]);
+      const p=state.players.find(pl=>pl.name.toLowerCase()===name.toLowerCase());
+      if(p){ p.projection=proj; matched++; }
+    }
+    showToast(`Loaded projections for ${matched} players`,'success');
+    renderPlayers();
+  } catch(err){
+    showToast(err.message,'error');
+  }
+}
 // Load a demo CSV by KEY (uses same pipeline as uploads)
 async function loadDemoCsv(key){
   state.isDemo = true;
@@ -460,18 +492,26 @@ function deriveFilters(){
   teamSel.innerHTML = '<option value="">All teams</option>';
   const teams=[...new Set(state.players.map(p=>p.team).filter(Boolean))].sort();
   teams.forEach(team=>{ const o=document.createElement('option'); o.value=team; o.textContent=team; teamSel.appendChild(o); });
+  document.getElementById('salarySort').value='';
+  state.statusFilter='';
 }
 
 function filteredPlayers(){
   const q=document.getElementById('searchPlayers').value.toLowerCase();
   const pf=document.getElementById('positionFilter').value;
   const tf=document.getElementById('teamFilter').value;
-  return state.players.filter(p=>{
+  const sf=document.getElementById('salarySort').value;
+  const status=state.statusFilter;
+  let arr = state.players.filter(p=>{
     const s=!q || p.name.toLowerCase().includes(q);
     const m=!pf || p.position===pf;
     const t=!tf || p.team===tf;
-    return s && m && t;
+    const st=!status || p.status===status;
+    return s && m && t && st;
   });
+  if(sf==='asc') arr.sort((a,b)=>a.salary-b.salary);
+  else if(sf==='desc') arr.sort((a,b)=>b.salary-a.salary);
+  return arr;
 }
 
 function renderPlayers(){ const cfg = SPORT_CONFIGS[state.detectedSport]; const body=document.getElementById('playerTableBody'); body.innerHTML = filteredPlayers().map(p=>{ const rowClass = p.status==='expected'? 'row-expected' : (p.status==='possible'? 'row-possible' : 'row-unexpected'); return `<tr class="${rowClass}">
@@ -480,6 +520,7 @@ function renderPlayers(){ const cfg = SPORT_CONFIGS[state.detectedSport]; const 
   <td>${esc(p.name)}</td>
   <td>${esc(p.position)}</td>
   <td>${esc(p.team||'')}</td>
+  <td>${p.projection!=null ? p.projection.toFixed(2) : ''}</td>
   <td>${cfg.currency}${p.salary}</td>
   <td><span class="helper" style="color:${p.status==='expected'?'#2fe089':p.status==='possible'?'#ffb86c':'#ff6b6b'}">${p.status}</span></td>
 </tr>`; }).join(''); }
@@ -540,7 +581,7 @@ function generateLineupsMaxSpend(){
   const tryBuild = (cap) => {
     const base=[]; let total=0;
     if(cap){ base.push(cap); total+=cap.salary; }
-    const others = pool.filter(p=>!cap || p.id!==cap.id);
+    const others = shuffle(pool.filter(p=>!cap || p.id!==cap.id));
 
     for (const p of others){
       if (base.length>=cfg.lineupSize) break;
@@ -585,11 +626,9 @@ function generateLineupsMaxSpend(){
   };
 
   let round=0;
-  while (out.length<N && round<N*4){
-    for (const cap of caps){
-      if (out.length>=N) break;
-      tryBuild(cap);
-    }
+  while (out.length<N && round<N*10){
+    const cap = caps[Math.floor(Math.random()*caps.length)];
+    tryBuild(cap);
     round++;
   }
 
@@ -630,6 +669,7 @@ async function processFile(file) {
       eventName: 'Imported CSV'
     };
     state.isDemo = false;
+
     uploadZone.classList.add('has-file');
     showToast(`Loaded ${players.length} players`, `success`);
     updateDetection();
@@ -659,6 +699,12 @@ document.getElementById('demoBtn').addEventListener('click', async () => {
 });
 
 document.getElementById('backToUpload').addEventListener('click',()=>setStep(1));
+const optFull=document.getElementById('optFull');
+const optShow=document.getElementById('optShow');
+function syncContestSelection(){
+  [optFull,optShow].forEach(x=>x.classList.remove('selected'));
+  (state.contestType==='showdown'?optShow:optFull).classList.add('selected');
+}
 document.getElementById('confirmSport').addEventListener('click', async () => {
   try {
     state.detectedSport = document.getElementById('sportSelector').value;
@@ -669,17 +715,18 @@ document.getElementById('confirmSport').addEventListener('click', async () => {
         const demo = await loadDemoCsv(key);
         state.players = demo.players;
         state.contestType = demo.contest;
+        state.currentDemoSport = demo.sport;
         state.datasetMeta = { tournament: demo.tournament, eventName: demo.eventName };
         updateDetection();
       }
     }
+    syncContestSelection();
     setStep(3);
   } catch (err) { showToast(err.message, 'error'); }
 });
 document.getElementById('backToSport').addEventListener('click',()=>setStep(2));
 
 // Contest selection
-const optFull=document.getElementById('optFull'); const optShow=document.getElementById('optShow');
 [optFull,optShow].forEach(el=> el.addEventListener('click',()=>{ [optFull,optShow].forEach(x=>x.classList.remove('selected')); el.classList.add('selected'); state.contestType = el.dataset.type; }));
 document.getElementById('confirmContest').addEventListener('click',()=>{
   const cfg = SPORT_CONFIGS[state.detectedSport];
@@ -707,15 +754,19 @@ document.getElementById('generateBtn').addEventListener('click', () => {
 });
 
 // Player controls
-document.getElementById('selectAll').addEventListener('click',()=>{ state.players.forEach(p=>p.selected=true); updateStats(); renderPlayers(); });
-document.getElementById('selectNone').addEventListener('click',()=>{ state.players.forEach(p=>{ p.selected=false; p.captain=false; }); updateStats(); renderPlayers(); });
-document.getElementById('selectExpected').addEventListener('click',()=>{ state.players.forEach(p=>{ p.selected = (p.status==='expected'); if(!p.selected) p.captain=false; }); updateStats(); renderPlayers(); });
+document.getElementById('selectAll').addEventListener('click',()=>{ state.players.forEach(p=>p.selected=true); state.statusFilter=''; updateStats(); renderPlayers(); });
+document.getElementById('selectNone').addEventListener('click',()=>{ state.players.forEach(p=>{ p.selected=false; p.captain=false; }); state.statusFilter=''; updateStats(); renderPlayers(); });
+document.getElementById('selectExpected').addEventListener('click',()=>{ state.players.forEach(p=>{ p.selected = (p.status==='expected'); if(!p.selected) p.captain=false; }); state.statusFilter='expected'; updateStats(); renderPlayers(); });
 document.getElementById('captainAll').addEventListener('click',()=>{ if(!usesCaptains(state.detectedSport, state.contestType)) return; state.players.filter(p=>p.selected).forEach(p=>p.captain=true); updateStats(); renderPlayers(); });
 document.getElementById('clearResults').addEventListener('click',()=>{ state.lineups=[]; renderLineups(); });
 document.getElementById('startOver').addEventListener('click',()=>{ state.players=[]; state.lineups=[]; state.currentDemoSport='nfl'; state.datasetMeta={tournament:'',eventName:''}; state.isDemo=false; document.getElementById('downloadBtn').setAttribute('disabled',''); uploadZone.classList.remove('has-file'); setStep(1); });
 document.getElementById('searchPlayers').addEventListener('input',renderPlayers);
 document.getElementById('positionFilter').addEventListener('change',renderPlayers);
 document.getElementById('teamFilter').addEventListener('change',renderPlayers);
+document.getElementById('salarySort').addEventListener('change',renderPlayers);
+
+document.getElementById('importProj').addEventListener('click',()=> document.getElementById('projInput').click());
+document.getElementById('projInput').addEventListener('change',e=>{ if(e.target.files.length) importProjections(e.target.files[0]); });
 
 // Expose for checkboxes
 window.toggleSelected = id => { const p=state.players.find(x=>x.id===id); if(!p) return; p.selected=!p.selected; if(!p.selected) p.captain=false; updateStats(); renderPlayers(); };


### PR DESCRIPTION
## Summary
- Add salary sorting and projection import controls to player management
- Track status filter so 'Expected only' hides other players
- Display imported projections in new table column
- Sync contest format with loaded demo data and allow multiple lineups per captain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c4ab60bc0c83299cc84d8e20043f86