### PR TITLE
Handle single-word display names

### DIFF
--- a/demo/naming_examples.csv
+++ b/demo/naming_examples.csv
@@ -1,0 +1,4 @@
+PlayerId,Name,First,Last,Salary
+1,Tom,Tom,Brady,5000
+2,,Jane,Doe,4500
+3,Alan Shearer,,,4000

--- a/index.html
+++ b/index.html
@@ -319,7 +319,16 @@ function buildDisplayName(row, cols){
   const d = cols.displayCol!==-1? (row[cols.displayCol]||'').trim() : '';
   const f = cols.firstCol!==-1?   (row[cols.firstCol]  ||'').trim() : '';
   const l = cols.lastCol!==-1?    (row[cols.lastCol]   ||'').trim() : '';
-  let name = d || (f && l ? `${f} ${l}` : (l || f));
+
+  let name = '';
+  if(d){
+    // If display column has only a given name, append last name when available
+    if(!d.includes(' ') && l && !looksNumericish(l)) name = `${d} ${l}`;
+    else name = d;
+  } else {
+    name = (f && l ? `${f} ${l}` : (l || f));
+  }
+
   if(!name || looksNumericish(name)){
     if(f && !looksNumericish(f)) name = f;
     if(l && !looksNumericish(l)) name = name ? `${name} ${l}` : l;

--- a/tests/buildDisplayName.test.js
+++ b/tests/buildDisplayName.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+
+function looksNumericish(s){ return /\d{3,}/.test((s||'').replace(/[.,\s]/g,'')); }
+function buildDisplayName(row, cols){
+  const d = cols.displayCol!==-1? (row[cols.displayCol]||'').trim() : '';
+  const f = cols.firstCol!==-1?   (row[cols.firstCol]  ||'').trim() : '';
+  const l = cols.lastCol!==-1?    (row[cols.lastCol]   ||'').trim() : '';
+
+  let name = '';
+  if(d){
+    if(!d.includes(' ') && l && !looksNumericish(l)) name = `${d} ${l}`;
+    else name = d;
+  } else {
+    name = (f && l ? `${f} ${l}` : (l || f));
+  }
+
+  if(!name || looksNumericish(name)){
+    if(f && !looksNumericish(f)) name = f;
+    if(l && !looksNumericish(l)) name = name ? `${name} ${l}` : l;
+  }
+  return (name||'').trim();
+}
+
+// Test 1: display column already has full name
+let row = ['', 'Alan Shearer', '', ''];
+let cols = { displayCol: 1, firstCol: 2, lastCol: 3 };
+assert.strictEqual(buildDisplayName(row, cols), 'Alan Shearer');
+
+// Test 2: display column only given name, last name available
+row = ['', 'Tom', 'Tom', 'Brady'];
+cols = { displayCol: 1, firstCol: 2, lastCol: 3 };
+assert.strictEqual(buildDisplayName(row, cols), 'Tom Brady');
+
+// Test 3: no display column, use first + last
+row = ['', '', 'Jane', 'Doe'];
+cols = { displayCol: -1, firstCol: 2, lastCol: 3 };
+assert.strictEqual(buildDisplayName(row, cols), 'Jane Doe');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- Append last name when display column only has a given name
- Document both naming patterns in demo/naming_examples.csv
- Add node-based tests verifying buildDisplayName name assembly

## Testing
- `node tests/buildDisplayName.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68c4b3e660bc8329881e47fbc674b832