### PR TITLE
Serve demo CSVs via relative public paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,14 +274,14 @@ hr.sep{border:none;border-top:1px solid #1b2131;margin:12px 0}
 <script>
 // -------------------- CONFIG --------------------
 
-// Real demo CSV datasets served via /demo path (mapped to public/demo)
+// Real demo CSV datasets served from public/demo via relative paths
 const DEMO_CSVS = {
-  nfl_full: { label:'NFL — Full slate', sport:'nfl', contest:'full-slate', tournament:'Tournament 1008839 (413 players)', eventName:'NFL Example Slate', url:'/demo/1008839_players_20250906222543.csv' },
-  nfl_show: { label:'NFL — Showdown', sport:'nfl', contest:'showdown', tournament:'Tournament 1009037 (33 players)', eventName:'NFL Showdown (Single Game)', url:'/demo/1009037_players_20250908102649.csv' },
-  fb_full:  { label:'Football — Full slate', sport:'football', contest:'full-slate', tournament:'Tournament 1009899 (845 players)', eventName:'Champions League Night', url:'/demo/1009899_players_20250908161603.csv' },
-  fb_show:  { label:'Football — Showdown', sport:'football', contest:'showdown', tournament:'Tournament 1010808 (51 players)', eventName:'Football Showdown', url:'/demo/1010808_players_20250908161619.csv' },
-  f1_full:  { label:'F1 — Race weekend', sport:'f1', contest:'full-slate', tournament:'Tournament 1008665 (29 players)', eventName:'F1 Race Weekend', url:'/demo/1008665_players_20250906172857.csv' },
-  golf_full:{ label:'Golf — PGA tournament', sport:'golf', contest:'full-slate', tournament:'Tournament 1000000 (585 players)', eventName:'PGA Tournament', url:'/demo/1000000_players_20250815093906.csv' }
+  nfl_full: { label:'NFL — Full slate', sport:'nfl', contest:'full-slate', tournament:'Tournament 1008839 (413 players)', eventName:'NFL Example Slate', url:'public/demo/1008839_players_20250906222543.csv' },
+  nfl_show: { label:'NFL — Showdown', sport:'nfl', contest:'showdown', tournament:'Tournament 1009037 (33 players)', eventName:'NFL Showdown (Single Game)', url:'public/demo/1009037_players_20250908102649.csv' },
+  fb_full:  { label:'Football — Full slate', sport:'football', contest:'full-slate', tournament:'Tournament 1009899 (845 players)', eventName:'Champions League Night', url:'public/demo/1009899_players_20250908161603.csv' },
+  fb_show:  { label:'Football — Showdown', sport:'football', contest:'showdown', tournament:'Tournament 1010808 (51 players)', eventName:'Football Showdown', url:'public/demo/1010808_players_20250908161619.csv' },
+  f1_full:  { label:'F1 — Race weekend', sport:'f1', contest:'full-slate', tournament:'Tournament 1008665 (29 players)', eventName:'F1 Race Weekend', url:'public/demo/1008665_players_20250906172857.csv' },
+  golf_full:{ label:'Golf — PGA tournament', sport:'golf', contest:'full-slate', tournament:'Tournament 1000000 (585 players)', eventName:'PGA Tournament', url:'public/demo/1000000_players_20250815093906.csv' }
 };
 
 // Rotation order for the demo button (array of KEYS)

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,6 @@ const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret';
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..')));
-app.use('/demo', express.static(path.join(__dirname, '..', 'public', 'demo')));
 
 function authenticate(req, res, next) {
   const header = req.headers['authorization'];


### PR DESCRIPTION
## Summary
- load demo CSVs using relative `public/demo` URLs in index.html
- remove obsolete `/demo` static route from server

## Testing
- `node tests/buildDisplayName.test.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d6791a948329927e51472fcf19a1