### PR TITLE
chore: output Vite build to dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 server/users.db
+
+dist/

--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,7 @@ const app = express();
 const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret';
 
 app.use(express.json());
-app.use(express.static(path.join(__dirname, '..', 'public')));
+app.use(express.static(path.join(__dirname, '..', 'dist')));
 
 function authenticate(req, res, next) {
   const header = req.headers['authorization'];

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "dist"
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vite to build into `dist`
- serve built files from `dist` and update Vercel config
- ignore compiled output directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c5e437a438832987a6be05120179f2