### PR TITLE
Require JWT secret environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # fanteam-optimizer-demo
 FanTeam Optimiser TOol
+
+## Deployment
+
+Set the `JWT_SECRET` environment variable before starting the server. The
+server will refuse to start if this variable is missing.
+
+```bash
+export JWT_SECRET=your-secret
+npm start
+```

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -4,7 +4,7 @@ const bcrypt = require('bcrypt');
 const User = require('../models/User');
 
 const router = express.Router();
-const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret';
+const JWT_SECRET = process.env.JWT_SECRET;
 
 router.post('/register', async (req, res) => {
   const { username, password, tier = 'free' } = req.body;

--- a/server/server.js
+++ b/server/server.js
@@ -4,7 +4,10 @@ const jwt = require('jsonwebtoken');
 const authRoutes = require('./routes/auth');
 
 const app = express();
-const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..', 'dist')));


### PR DESCRIPTION
## Summary
- remove fallback JWT secret and require JWT_SECRET environment variable
- document JWT_SECRET requirement in deployment instructions

## Testing
- `npm test -- --run`
- `node server/server.js` *(fails without JWT_SECRET)*
- `JWT_SECRET=secret node server/server.js`

------
https://chatgpt.com/codex/tasks/task_b_68c5ebe472448329aa4343ef6207d1fd