### PR TITLE
chore: enable ESM and Vite scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
+        "vite": "^7.1.5",
         "vitest": "^3.2.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "main": "server/server.js",
   "scripts": {
     "test": "vitest",
-    "start": "node server/server.js"
+    "start": "node server/server.js",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "bcrypt": "^6.0.0",
     "express": "^5.1.0",
@@ -18,6 +21,7 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vite": "^7.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- switch project to ES modules
- add Vite dev/build/preview scripts
- align package-lock and dev dependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c5effe65788329ae9d4a51a071c742