### PR TITLE
Resolve buildDisplayName test conflicts

### DIFF
--- a/tests/buildDisplayName.test.js
+++ b/tests/buildDisplayName.test.js
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
 
 function looksNumericish(s) {
   return /\d{3,}/.test((s || '').replace(/[.,\s]/g, ''));
@@ -28,18 +29,30 @@ describe('buildDisplayName', () => {
   it('display column already has full name', () => {
     const row = ['', 'Alan Shearer', '', ''];
     const cols = { displayCol: 1, firstCol: 2, lastCol: 3 };
-    expect(buildDisplayName(row, cols)).toBe('Alan Shearer');
+    assert.strictEqual(buildDisplayName(row, cols), 'Alan Shearer');
   });
 
   it('display column only given name, last name available', () => {
     const row = ['', 'Tom', 'Tom', 'Brady'];
     const cols = { displayCol: 1, firstCol: 2, lastCol: 3 };
-    expect(buildDisplayName(row, cols)).toBe('Tom Brady');
+    assert.strictEqual(buildDisplayName(row, cols), 'Tom Brady');
   });
 
   it('no display column, use first + last', () => {
     const row = ['', '', 'Jane', 'Doe'];
     const cols = { displayCol: -1, firstCol: 2, lastCol: 3 };
-    expect(buildDisplayName(row, cols)).toBe('Jane Doe');
+    assert.strictEqual(buildDisplayName(row, cols), 'Jane Doe');
+  });
+
+  it('numeric display column falls back to first and last names', () => {
+    const row = ['', '123456', 'Tom', 'Brady'];
+    const cols = { displayCol: 1, firstCol: 2, lastCol: 3 };
+    assert.strictEqual(buildDisplayName(row, cols), 'Tom Brady');
+  });
+
+  it('numeric last name ignored when display only first name', () => {
+    const row = ['', 'Tom', 'Tom', '123456'];
+    const cols = { displayCol: 1, firstCol: 2, lastCol: 3 };
+    assert.strictEqual(buildDisplayName(row, cols), 'Tom');
   });
 });


### PR DESCRIPTION
## Summary
- use ESM with Node's assert and vitest for buildDisplayName test
- expand tests to cover numeric display and last name cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c5efff54f8832987e7561a1447a3dd