### PR TITLE
Configure Vercel build and output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
-  "outputDirectory": "dist"
+  "buildCommand": "npm run build",
+  "outputDirectory": "public"
 }


### PR DESCRIPTION
## Summary
- set Vercel build command to `npm run build`
- output build artifacts to `public`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c5f001c0fc8329bb6274e95216c8a4