### PR TITLE
fix: import toast helper in auth script

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -1,3 +1,5 @@
+import { showToast } from './src/ui/toast.js';
+
 // Simple authentication client
 let authToken = null;
 let userTier = 'free';


### PR DESCRIPTION
## Summary
- import `showToast` in the public auth script to enable toast notifications

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68c5f03eef788329aa71668f1dfbc419