### PR TITLE
refactor: validate env variables

### DIFF
--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -2,7 +2,17 @@ import { z } from 'zod';
 
 const envSchema = z.object({
   JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
-  PORT: z.string().optional(),
+  PORT: z.coerce.number().int().default(3000),
 });
 
-export const env = envSchema.parse(process.env);
+const _env = envSchema.safeParse(process.env);
+
+if (!_env.success) {
+  console.error(
+    'Invalid environment variables',
+    _env.error.flatten().fieldErrors,
+  );
+  process.exit(1);
+}
+
+export const env = _env.data;


### PR DESCRIPTION
## Summary
- enforce typed validation for JWT_SECRET and PORT
- fail fast on invalid environment variables

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68c6980a59208329bb856601326b8ab6