### PR TITLE
feat(server): add CLIENT_ORIGIN env for CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment configuration
+JWT_SECRET=your-secret
+PORT=3000
+# URL of the client application for CORS
+CLIENT_ORIGIN=http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ FanTeam Optimizer Tool
 ## Deployment
 
 Set the `JWT_SECRET` environment variable before starting the server. The
-server will refuse to start if this variable is missing.
+server will refuse to start if this variable is missing. Optionally set
+`CLIENT_ORIGIN` to the URL of your frontend to configure CORS.
 
 ```bash
 export JWT_SECRET=your-secret

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
+        "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-rate-limit": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -18,6 +19,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.3.3",
@@ -1017,6 +1019,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2024,6 +2036,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/cross-spawn": {
@@ -3949,6 +3974,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "author": "",
   "dependencies": {
     "bcrypt": "^6.0.0",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "express-rate-limit": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -11,6 +12,7 @@
   "description": "FanTeam Optimizer Tool",
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.3.3",

--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 const envSchema = z.object({
   JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
   PORT: z.coerce.number().int().default(3000),
+  CLIENT_ORIGIN: z.string().url().optional(),
 });
 
 const _env = envSchema.safeParse(process.env);

--- a/server/server.ts
+++ b/server/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import path from 'path';
 import jwt from 'jsonwebtoken';
 import rateLimit from 'express-rate-limit';
+import cors from 'cors';
 import authRoutes from './routes/auth';
 import { env } from './lib/env';
 import type { JwtPayload, VerifyErrors } from 'jsonwebtoken';
@@ -9,7 +10,13 @@ import type { JwtPayload, VerifyErrors } from 'jsonwebtoken';
 const app = express();
 const JWT_SECRET = env.JWT_SECRET;
 const PORT = Number(env.PORT) || 3000;
+const CLIENT_ORIGIN = env.CLIENT_ORIGIN;
 
+app.use(
+  cors({
+    origin: CLIENT_ORIGIN,
+  }),
+);
 app.use(express.json());
 app.use(rateLimit({ windowMs: 60_000, max: 60 }));
 app.use(express.static(path.join(process.cwd(), 'dist')));


### PR DESCRIPTION
## Summary
- allow configuring CORS origin via CLIENT_ORIGIN environment variable
- document CLIENT_ORIGIN and provide example in `.env.example`
- add `cors` dependency and hook into Express

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck` *(fails: Could not find a declaration file for module '../models/User')*

------
https://chatgpt.com/codex/tasks/task_b_68c713c761908329994a8d75cf3f5750