### PR TITLE
feat: export env schema and validate optional origin

### DIFF
--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 
-const envSchema = z.object({
+export const EnvSchema = z.object({
   JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
   PORT: z.coerce.number().int().default(3000),
-  CLIENT_ORIGIN: z.string().optional(),
+  CLIENT_ORIGIN: z.string().url().optional().or(z.literal('')),
 });
 
-const _env = envSchema.safeParse(process.env);
+const _env = EnvSchema.safeParse(process.env);
 
 if (!_env.success) {
   console.error(


### PR DESCRIPTION
## Summary
- export EnvSchema and allow optional CLIENT_ORIGIN urls or empty string
- parse environment variables using EnvSchema

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Could not find a declaration file for module '../models/User'; Cannot find module 'helmet' or its corresponding type declarations; Cannot find module 'cors' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_68c71cd873e88329a48f623a3d86944b