### PR TITLE
chore: pin cors dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
-        "cors": "^2.8.5",
+        "cors": "2.8.5",
         "express": "^5.1.0",
         "express-rate-limit": "^8.1.0",
         "helmet": "^8.1.0",
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
-        "@types/cors": "^2.8.19",
+        "@types/cors": "2.8.19",
         "@types/express": "^5.0.3",
         "@types/helmet": "^0.0.48",
         "@types/jsonwebtoken": "^9.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "",
   "dependencies": {
     "bcrypt": "^6.0.0",
-    "cors": "^2.8.5",
+    "cors": "2.8.5",
     "express": "^5.1.0",
     "express-rate-limit": "^8.1.0",
     "helmet": "^8.1.0",
@@ -13,7 +13,7 @@
   "description": "FanTeam Optimizer Tool",
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
-    "@types/cors": "^2.8.19",
+    "@types/cors": "2.8.19",
     "@types/express": "^5.0.3",
     "@types/helmet": "^0.0.48",
     "@types/jsonwebtoken": "^9.0.10",


### PR DESCRIPTION
## Summary
- pin `cors` and `@types/cors` to explicit versions in package.json
- regenerate package-lock.json

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c71cda1afc83298ce8c9ef147b90cc