### PR TITLE
feat: add vercel api functions and update build

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,6 +7,8 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     sourceType: 'module',
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint', 'prettier'],
   extends: [
@@ -14,4 +16,5 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
   ],
+  ignorePatterns: ['dist'],
 };

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-package-lock.json merge=ours
 * text=auto eol=lf
+package-lock.json merge=ours

--- a/api/auth/[...slug].ts
+++ b/api/auth/[...slug].ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import authRoutes from '../../server/routes/auth';
+
+const app = express();
+app.use(express.json());
+app.use(authRoutes);
+
+export default app;

--- a/api/health.ts
+++ b/api/health.ts
@@ -1,0 +1,10 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+
+export default function handler(
+  _req: IncomingMessage,
+  res: ServerResponse,
+): void {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ status: 'ok' }));
+}

--- a/docs/TRANSPARENCY.md
+++ b/docs/TRANSPARENCY.md
@@ -6,3 +6,4 @@ In the interest of transparency and accountability, below is information about t
 - **Process:** The model was given task instructions and a development environment, and it made a best effort to apply changes and run tests.
 - **Limitations:** The model may make mistakes or produce incomplete solutions.
 - **Reproduction:** See the testing section of the accompanying pull request for commands to reproduce the results.
+- **Commands:** `npm install --include=dev`, `npm run lint`, `npm run typecheck`, `npm test -- --run`, `npm run build`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3135,15 +3135,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -4950,9 +4941,9 @@
       "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "main": "dist/server/server.js",
   "name": "fanteam-optimizer-demo",
   "scripts": {
-    "build": "tsc",
+    "build": "vite build && tsc",
     "format": "prettier --write .",
     "lint": "eslint \"**/*.{ts,tsx}\" --no-error-on-unmatched-pattern",
     "start": "node dist/server/server.js",

--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const EnvSchema = z.object({
   JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
   PORT: z.coerce.number().int().default(3000),
-  CLIENT_ORIGIN: z.string().url().optional().or(z.literal('')),
+  CLIENT_ORIGIN: z.string().url().optional().default(''),
 });
 
 const _env = EnvSchema.safeParse(process.env);

--- a/server/models/User.d.ts
+++ b/server/models/User.d.ts
@@ -1,0 +1,17 @@
+interface DbUser {
+  id: number;
+  username: string;
+  password: string;
+  tier: string;
+}
+
+declare const User: {
+  createUser(
+    username: string,
+    password: string,
+    tier: string,
+  ): Promise<Omit<DbUser, 'password'>>;
+  findByUsername(username: string): Promise<DbUser | undefined>;
+};
+
+export default User;

--- a/server/server.ts
+++ b/server/server.ts
@@ -49,4 +49,8 @@ app.get('/api/protected', authenticate, (req: RequestWithUser, res) => {
   res.json({ message: `Hello ${user.username}!`, tier: user.tier });
 });
 
-app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+if (process.env.VERCEL !== '1') {
+  app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+}
+
+export default app;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,10 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "dist"
   },
-  "include": ["src", "server", "tests"],
+  "include": ["src", "server", "api", "tests"],
   "exclude": ["node_modules", "dist"]
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,8 @@
 {
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "functions": {
+    "api/**": {
+      "runtime": "nodejs18.x"
+    }
+  }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  root: 'ui',
   build: {
-    outDir: 'dist'
-  }
+    outDir: '../dist',
+    emptyOutDir: false,
+  },
+  test: {
+    root: './',
+    include: ['tests/**/*.{test,spec}.js'],
+  },
 });


### PR DESCRIPTION
## Summary
- configure ESLint for project tsconfig and ignore dist output
- add Vercel API functions for auth and health checks and expose express app for serverless environments
- update build tooling and config for Vite/TypeScript and document commands

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c72e4d343083299416d50f065898d8