### PR TITLE
Map soccer demo data to football slug

### DIFF
--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -13,7 +13,8 @@ export type SportKey =
 
 export function demoUrlFor(sport: SportKey): string | undefined {
   // default location for shipped static assets
-  return `/demo/${sport}/players.csv`;
+  const slug = sport === 'soccer' ? 'football' : sport;
+  return `/demo/${slug}/players.csv`;
 }
 
 export async function fetchDemoCsv(sport: SportKey): Promise<string> {


### PR DESCRIPTION
## Summary
- map the soccer sport key to the football demo folder so the shipped CSV is used

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c98ae5a0848329a07105a4ee68dd36